### PR TITLE
Adding union for PR review

### DIFF
--- a/union/union.js
+++ b/union/union.js
@@ -1,0 +1,26 @@
+//Iteration 1 - without reduce:
+const union = (...arrays) => {
+    let uniqueNumbers = new Set();
+
+    for (let i=0; i<arrays.length; i++) {
+        let eachArray = arrays[i];
+        for (let ii=0; ii<eachArray.length; ii++) {
+            uniqueNumbers.add(eachArray[ii]);
+        }
+    }
+    return Array.from(uniqueNumbers);
+
+};
+
+//Iteration 2 - with reduce 
+const union = (...arrays) => {
+    let uniqueNumbers = new Set();
+    let finder = arrays.reduce((acc, val) => {
+        val.forEach(function(element){      
+            return uniqueNumbers.has(val) ? acc : uniqueNumbers.add(element);
+        })
+    }, 0)
+     return Array.from(uniqueNumbers);
+};
+
+console.log(union([5, 10, 15], [15, 88, 1, 5, 7], [100, 15, 10, 1, 5]));


### PR DESCRIPTION
@paulghaddad I'd like to get your input on this problem. Here's the problem statement:

Construct a function union that compares input arrays and returns a new array that contains all elements. If there are duplicate elements, only add it once to the new array. Preserve the order of the elements starting from the first element of the first input array. BONUS: Use reduce!

I did this problem once without reduce() and now I'm using it, and running into issues. When I run the code with the double return I get ALL of the values back: 
Set {
  [ [ 5, 10, 15 ] ],
  [ [ 15, 88, 1, 5, 7 ] ],
  [ [ 100, 15, 10, 1, 5 ] ] }

If I don't use the double return I get "undefined". 

I'm trying to do this: if the set has the current number then keep the `acc` value as is. If not, add it to the set. 